### PR TITLE
Eliminate an AST level for sort AST nodes

### DIFF
--- a/src/parsers/smt2new/smt2newparser.yy
+++ b/src/parsers/smt2new/smt2newparser.yy
@@ -313,7 +313,7 @@ identifier: TK_SYM
     ;
 
 sort: identifier
-      { $$ = new ASTNode(ID_T, NULL); $$->children = new std::vector<ASTNode*>(); $$->children->push_back($1); }
+      { $$ = $1; }
     | '(' identifier sort sort_list ')'
       {
         $$ = new ASTNode(LID_T, NULL);


### PR DESCRIPTION
This makes the use of `Interpret::buildSortName` more consistent and has the additional benefit of generating slightly smaller AST.
